### PR TITLE
Utilizing app connections for network

### DIFF
--- a/nullstone.tf
+++ b/nullstone.tf
@@ -8,15 +8,19 @@ terraform {
 
 data "ns_workspace" "this" {}
 
-data "ns_connection" "cluster" {
-  name = "cluster"
-  type = "cluster/aws-fargate"
+// Container apps have clusters, but lambdas do not
+// If app does not have cluster, resulting `name` equals `""`
+// This allows the `via` in the network stanza to work as if the cluster did not exist
+data "ns_app_connection" "cluster" {
+  name     = "cluster"
+  type     = "cluster/aws-fargate"
+  optional = true
 }
 
-data "ns_connection" "network" {
+data "ns_app_connection" "network" {
   name = "network"
   type = "network/aws"
-  via  = data.ns_connection.cluster.name
+  via  = data.ns_app_connection.cluster.name
 }
 
 data "ns_connection" "subdomain" {


### PR DESCRIPTION
This utilizes the new data source created in https://github.com/nullstone-io/terraform-provider-ns/pull/16.
This effectively removes the `cluster` connection from this module's manifest.
Instead, the `network` is retrieved from the app's connections.
This will work regardless if the app has a cluster or not.