### PR TITLE
Creating security group rules in capability

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,8 @@
 output "load_balancers" {
   value = [
     {
-      port              = aws_lb_target_group.this.port
-      target_group_arn  = aws_lb_target_group.this.arn
-      security_group_id = aws_security_group.lb.id
+      port             = aws_lb_target_group.this.port
+      target_group_arn = aws_lb_target_group.this.arn
     }
   ]
 }

--- a/security.tf
+++ b/security.tf
@@ -13,3 +13,21 @@ resource "aws_security_group_rule" "lb-http-from-world" {
   from_port         = 80
   to_port           = 80
 }
+
+resource "aws_security_group_rule" "lb-http-to-app" {
+  security_group_id        = aws_security_group.lb.id
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = aws_lb_target_group.this.port
+  to_port                  = aws_lb_target_group.this.port
+  source_security_group_id = var.app_metadata["security_group_id"]
+}
+
+resource "aws_security_group_rule" "app-http-from-lb" {
+  security_group_id        = var.app_metadata["security_group_id"]
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = aws_lb_target_group.this.port
+  to_port                  = aws_lb_target_group.this.port
+  source_security_group_id = aws_security_group.lb.id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,13 @@
+variable "app_metadata" {
+  description = <<EOF
+App Metadata is injected from the app on-the-fly.
+This contains information about resources created in the app module that are needed by the capability.
+EOF
+  
+  type    = map(string)
+  default = {}
+}
+
 variable "service_port" {
   description = "The load balancer will forward to this port on your service"
   type        = number


### PR DESCRIPTION
This moves security group rule creation into the capability as a result of dealing with issues doing dynamic count in terraform.