### PR TITLE
Use service_port from app_metadata

### DIFF
--- a/target-group.tf
+++ b/target-group.tf
@@ -1,6 +1,6 @@
 resource "aws_lb_target_group" "this" {
   name                 = local.resource_name
-  port                 = var.service_port
+  port                 = var.app_metadata["service_port"]
   protocol             = "HTTP"
   target_type          = "ip"
   vpc_id               = local.vpc_id

--- a/variables.tf
+++ b/variables.tf
@@ -8,12 +8,6 @@ EOF
   default = {}
 }
 
-variable "service_port" {
-  description = "The load balancer will forward to this port on your service"
-  type        = number
-  default     = 80
-}
-
 variable "enable_https" {
   description = "Enable this to serve up HTTPS traffic. Requires subdomain connection."
   type        = bool


### PR DESCRIPTION
This PR removes configuration for `service_port`.
It is very confusing to the user to configure 2 `service_port` options when launching apps that have a load balancer.

![image](https://user-images.githubusercontent.com/830878/131399335-8cc84741-385b-496f-b0d9-a14665c11d62.png)

Beginning in aws-fargate-service@0.9.0, `service_port` is passed to every capability via `app_metadata` (https://github.com/nullstone-modules/aws-fargate-service/pull/22)
