### PR TITLE
Fix aws provider

### DIFF
--- a/logs_bucket/main.tf
+++ b/logs_bucket/main.tf
@@ -1,8 +1,6 @@
 resource "aws_s3_bucket" "default" {
   bucket        = var.name
-  acl           = "log-delivery-write"
   force_destroy = var.force_destroy
-  policy        = data.aws_iam_policy_document.default.json
   tags          = merge({ Name : var.name }, var.tags)
 }
 

--- a/logs_bucket/policy.tf
+++ b/logs_bucket/policy.tf
@@ -1,3 +1,36 @@
+resource "aws_s3_bucket_acl" "default" {
+  bucket = aws_s3_bucket.default.id
+  acl    = "log-delivery-write"
+}
+
+resource "aws_s3_bucket_policy" "default" {
+  bucket = aws_s3_bucket.default.bucket
+  policy = data.aws_iam_policy_document.this.json
+}
+
+data "aws_elb_service_account" "this" {}
+
+data "aws_iam_policy_document" "this" {
+  statement {
+    sid = ""
+
+    principals {
+      type        = "AWS"
+      identifiers = [join("", data.aws_elb_service_account.this.*.arn)]
+    }
+
+    effect = "Allow"
+
+    actions = [
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.name}/*",
+    ]
+  }
+}
+
 data "aws_elb_service_account" "default" {}
 
 data "aws_iam_policy_document" "default" {


### PR DESCRIPTION
This PR updates the submodule `logs_bucket` to utilize the upgraded aws provider (4.x+).
This required breaking out the s3 bucket configuration into separate terraform resources.