### PR TITLE
Fixing recreation of target group initiated by change in service port

### DIFF
--- a/target-group.tf
+++ b/target-group.tf
@@ -1,5 +1,5 @@
 resource "aws_lb_target_group" "this" {
-  name                 = local.resource_name
+  name                 = "${local.resource_name}-${var.app_metadata["service_port"]}"
   port                 = var.app_metadata["service_port"]
   protocol             = "HTTP"
   target_type          = "ip"


### PR DESCRIPTION
When changing the `service_port` of an application, this causes an attached load balancer capability to recreate the target group (connection between load balancer and ecs service).
This PR forces a new target group to be created and connected before destroying the existing one.