### PR TITLE
Upgrade terraform providers and locked with `.terraform.lock.hcl`.

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,102 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.41.0"
+  hashes = [
+    "h1:/jcTPBFogo2igFvTcXelgD4EQ+Ty0oNXAh7ZLLxqcng=",
+    "h1:DiX7N35G2NUQRyRGy90+gyePnhP4w77f8LrJUronotE=",
+    "h1:SgIWBDBA1uNB/Y7CaLFeNX/Ju2xboSSQmRv35Vbi46M=",
+    "h1:ftTyCk04Ec0SCvYkFF2afTDrYy84LqOdZgbWAy7n9BM=",
+    "h1:uNln7837/ZTVgQBk+hhfgB9Y87icES6X0lMSOfK5c7g=",
+    "zh:0553331a6287c146353b6daf6f71987d8c000f407b5e29d6e004ea88faec2e67",
+    "zh:1a11118984bb2950e8ee7ef17b0f91fc9eb4a42c8e7a9cafd7eb4aca771d06e4",
+    "zh:236fedd266d152a8233a7fe27ffdd99ca27d9e66a9618a988a4c3da1ac24a33f",
+    "zh:34bc482ea04cf30d4d216afa55eecf66854e1acf93892cb28a6b5af91d43c9b7",
+    "zh:39d7eb15832fe339bf46e3bab9852280762a1817bf1afc459eecd430e20e3ad5",
+    "zh:39fb07429c51556b05170ec2b6bd55e2487adfe1606761eaf1f2a43c4bb20e47",
+    "zh:71d7cd3013e2f3fa0f65194af29ee6f5fa905e0df2b72b723761dc953f4512ea",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9b271ae12394e7e2ce6da568b42226a146e90fd705e02a670fcb93618c4aa19f",
+    "zh:a884dd978859d001709681f9513ba0fbb0753d1d459a7f3434ecc5f1b8699c49",
+    "zh:b8c3c7dc10ae4f6143168042dcf8dee63527b103cc37abc238ea06150af38b6e",
+    "zh:ba94ffe0893ad60c0b70c402e163b4df2cf417e93474a9cc1a37535bba18f22d",
+    "zh:d5ba851d971ff8d796afd9a100acf55eaac0c197c6ab779787797ce66f419f0e",
+    "zh:e8c090d0c4f730c4a610dc4f0c22b177a0376d6f78679fc3f1d557b469e656f4",
+    "zh:ed7623acde26834672969dcb5befdb62900d9f216d32e7478a095d2b040a0ea7",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.6.0"
+  hashes = [
+    "h1:5KeoKSVKVHJW308uiTgslxFbjQAdWzBGUFK68vgMRWY=",
+    "h1:I8MBeauYA8J8yheLJ8oSMWqB0kovn16dF/wKZ1QTdkk=",
+    "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
+    "h1:p6WG1IPHnqx1fnJVKNjv733FBaArIugqy58HRZnpPCk=",
+    "h1:t0mRdJzegohRKhfdoQEJnv3JRISSezJRblN0HIe67vo=",
+    "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
+    "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
+    "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",
+    "zh:30ffb297ffd1633175d6545d37c2217e2cef9545a6e03946e514c59c0859b77d",
+    "zh:454ce4b3dbc73e6775f2f6605d45cee6e16c3872a2e66a2c97993d6e5cbd7055",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:91df0a9fab329aff2ff4cf26797592eb7a3a90b4a0c04d64ce186654e0cc6e17",
+    "zh:aa57384b85622a9f7bfb5d4512ca88e61f22a9cea9f30febaa4c98c68ff0dc21",
+    "zh:c4a3e329ba786ffb6f2b694e1fd41d413a7010f3a53c20b432325a94fa71e839",
+    "zh:e2699bc9116447f96c53d55f2a00570f982e6f9935038c3810603572693712d0",
+    "zh:e747c0fd5d7684e5bfad8aa0ca441903f15ae7a98a737ff6aca24ba223207e2c",
+    "zh:f1ca75f417ce490368f047b63ec09fd003711ae48487fba90b4aba2ccf71920e",
+  ]
+}
+
+provider "registry.terraform.io/nullstone-io/ns" {
+  version = "0.6.22"
+  hashes = [
+    "h1:1pJP5/RweaOf8v5uWVLyIIO9+yKMcY0GdRZiADGZMWc=",
+    "h1:T80dWkdEuI69zRY2UXm255iW+2UiedaNsuARrLp/3OY=",
+    "h1:TOVxLHvpui8TZ3/ehqJe6hcKeETSTTbIGtGTloO2/Pc=",
+    "h1:XOyqJRPTzXpSgkZGQvbmyzTKbvPNsI8smkQsc2sZKMA=",
+    "h1:aMFqeu5KNBrJVN9w7fQFZHG+dF95BMxEKmBWKfRMjfQ=",
+    "zh:003ead5999768765dc0b9a0becaaddd6c8f1088b115f29604f6aaa2dc6e12f29",
+    "zh:10cf75e381320ed161a70d70fa87d59bd42810666cba62c81cb3e13c9bab8998",
+    "zh:28a9efb91fe63dad2c125fd4ff024acfad2c7f33d8f966e138693ad54da84fc7",
+    "zh:48058858531a60408fc9cfd0b5a118797b53bb83fe68d1d42706b38ee12c3e5b",
+    "zh:6cdb78a5d73b929f58c9f70cdb5fec69e0b861a3b620018715faa80d0487a387",
+    "zh:8814db8f832b37a8e3d318d8942a29ca310ed9a1737f40612a3d05a6113a23e9",
+    "zh:9d105689d10cfcfe32221aed5593c67ab7dba5365773cb0c0a518f7cac81de73",
+    "zh:ad187f7db65e81379cd48efeb4889f3e2d14f476d5a18ce63d623d0f45ea1b85",
+    "zh:bcea05968f4f17e643eb96aeffdb5b53dcc2debfece8dd18899cfe894e816bef",
+    "zh:ce36676f6ca6884d0fc993873245b8a2902758e582a371ecce1bf4f7b27eabcf",
+    "zh:d96e0432dcbba73ac97b86a86dc3cdf5d6bfdd7a201893e7e61c2382e99750c2",
+    "zh:ea357c702917049dbc249eb6fa22b8906ee4d47335c92717e9e2910fdc429290",
+    "zh:ec062b98f2bd7d149ae98c8a7d791a95fe0f5d7aac4907e95f73f077b08a33a6",
+    "zh:f24ab46165449884ed8e761b005fb0be0e3c72382d94d1fd230871b5e12ea331",
+  ]
+}
+
+provider "registry.terraform.io/tlkamp/validation" {
+  version = "1.1.1"
+  hashes = [
+    "h1:+8uezEF+VWpZcD0D5JwjXIBEI4S3o8YnFECkzXBEdyg=",
+    "h1:O+lg+RbRMPUaaCyLIFynlY1OsMdcsp/4cIiCwCvMuL0=",
+    "h1:SfB34bDWa++DoBV52RErBjJiLsvxRpaONkU4DRdRnYE=",
+    "h1:WU8D4QtfSXD7Idn8YgxxwH+tQ/YXV8pYj1bb8MG6G8s=",
+    "h1:j+Uh0/z9XItqtUy1ScC9umtx/E5Y1drB4LvNgnNBKdQ=",
+    "zh:05f2e8fc4e4f1e6df8e86d2d60a250efc1dd2dd41b46809db404ee44c82d5bfb",
+    "zh:099911ff27fd8b2e94ffa5c5ca8e7041c95f86ffd82a072b96a72df715b57471",
+    "zh:118db3394d3aa93648e7a4b5bce5062fe961096c129844bd4123e04cc675562e",
+    "zh:16f91aa6db46702d911738f2fa895a328db2e36cad42a8c4c8c4710d30ce2115",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:32664186e5fcbcc9ed5557c530bbbc481f2e1dd129645e22ee616dfd85dd935e",
+    "zh:38935bfc992217bdb5681516dec5c8c0031e591cb67a93ed5281359aac56d0f3",
+    "zh:55ebe724ad97ea839c651d2b8e416ff9ddb6af2836fa14a43e8f1a1f389c5ee2",
+    "zh:573afad90cd5720cce02aade87a24863e7188cb118d411c6736c0180eee9c0a9",
+    "zh:5ec4de07f45b08bd7c1e8822344cd41625e805d7e10d5548f30c4fddf0eb153a",
+    "zh:7be4a994bbb3e03f5eaf11009aea2a61b429b65a6dc616e73c7ef2d78d33f07f",
+    "zh:928f7e3ce74ddddb92cdd8a4facc09ce573c0946407f023c90fd8ac1f1b3a56e",
+    "zh:a860caa99f0e143e41da32ce4013ab19b12acc02a3ffb3f31bb7e657c5aa71e4",
+    "zh:b08e0cd7b21ae126c694b3b3e5dd9d285b3f56126ec4d29d5d7dee46219da487",
+    "zh:c5d113053435d627d3c9a28591ba54cd405848ecdc0e23b9fecb312437997cbe",
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.5.3 (Mar 19, 2024)
+* Upgrade terraform providers and locked with `.terraform.lock.hcl`.
+
 # 0.5.2 (Feb 06, 2024)
 * Added initial metrics.
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+lock-providers:
+	terraform providers lock -platform=linux_amd64 -platform=linux_arm64 -platform=darwin_amd64 -platform=darwin_arm64 -platform=windows_amd64


### PR DESCRIPTION
I started seeing the following error when trying to destroy an app with a connected load balancer:
```
Error: waiting for delete Amazon S3 (Simple Storage) Bucket (brown-sea-lion-xvyqq): found resource
```

This attempts to fix by upgrading the terraform providers and locking.