### PR TITLE
Added vars for `desync_mitigation_mode` and `drop_invalid_header_fields`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.5.4 (Apr 03, 2024)
+* Added vars for `desync_mitigation_mode` and `drop_invalid_header_fields`.
+
 # 0.5.3 (Mar 19, 2024)
 * Upgrade terraform providers and locked with `.terraform.lock.hcl`.
 

--- a/lb.tf
+++ b/lb.tf
@@ -8,6 +8,9 @@ resource "aws_lb" "this" {
   ip_address_type    = "ipv4"
   tags               = local.tags
 
+  desync_mitigation_mode     = var.desync_mitigation_mode
+  drop_invalid_header_fields = var.drop_invalid_header_fields
+
   access_logs {
     bucket  = module.logs_bucket.bucket_id
     enabled = true

--- a/variables.tf
+++ b/variables.tf
@@ -114,3 +114,28 @@ EOF
     error_message = "The following cookie names are reserved for AWS and invalid: 'AWSALB', 'AWSALBAPP', 'AWSALBTG'."
   }
 }
+
+variable "desync_mitigation_mode" {
+  type        = string
+  default     = "defensive"
+  description = <<EOF
+Determines how the load balancer handles requests that might pose a security risk to an application due to HTTP desync.
+Valid values are monitor, defensive (default), strictest.
+See more at [config-desync-mitigation-mode](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-desync-mitigation-mode.html).
+EOF
+
+  validation {
+    condition     = contains(["monitor", "defensive", "strictest"], var.desync_mitigation_mode)
+    error_message = "desync_mitigation_mode must be one of 'monitor', 'defensive', or 'strictest'."
+  }
+}
+
+variable "drop_invalid_header_fields" {
+  type        = bool
+  default     = false
+  description = <<EOF
+Indicates whether HTTP headers with header fields that are not valid are removed by the load balancer (true) or routed to targets (false).
+The default is false.
+Elastic Load Balancing requires that message header names contain only alphanumeric characters and hyphens.
+EOF
+}


### PR DESCRIPTION
Added variables for configuring load balancer security.
The default values for `desync_mitigation_mode` and `drop_invalid_header_fields` flag vulnerability scanners.