### PR TITLE
Added context to the name of the metrics charts

### DIFF
--- a/metrics.tf
+++ b/metrics.tf
@@ -4,9 +4,11 @@ locals {
     "TargetGroup"  = aws_lb_target_group.this.arn_suffix
   })
 
+  metric_name_prefix = "load-balancer/${random_string.resource_suffix.result}"
+
   metrics = [
     {
-      name = "hosts"
+      name = "${local.metric_name_prefix}/hosts"
       type = "generic"
       unit = "count"
 
@@ -28,7 +30,7 @@ locals {
       }
     },
     {
-      name = "requests"
+      name = "${local.metric_name_prefix}/requests"
       type = "generic"
       unit = "count"
 
@@ -57,7 +59,7 @@ locals {
       }
     },
     {
-      name = "response"
+      name = "${local.metric_name_prefix}/response"
       type = "duration"
       unit = "seconds"
 


### PR DESCRIPTION
This adds context to the chart title. Previously, each chart would say something like `response`.
Now (seen in screenshot), it shows `load-balancer/<unique-ref>/response`.

![image](https://github.com/user-attachments/assets/a4b31605-6e33-4ca4-9a61-8f733dcecbce)
